### PR TITLE
expose error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,9 @@ Logger.prototype.send = function(level, type, msg){
   var n = levels[level];
   if (n < this.filter) return;
 
+  // expose error messages
+  if (msg instanceof Error) msg = clone(msg);
+
   // default msg
   if (null == msg) msg = {};
 
@@ -122,3 +125,17 @@ Object.keys(levels).forEach(function(level){
     this.send(level, type, msg);
   };
 });
+
+/**
+ * Clone `err` with enumerable `.message`.
+ *
+ * @param {Error} err
+ * @return {Object}
+ * @api private
+ */
+
+function clone(err){
+  var ret = { message: err.message };
+  for (var key in err) ret[key] = err[key];
+  return ret;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,25 @@ describe('Logger#send(level, type, msg)', function(){
     var log = new Logger('tcp://localhost:5555');
     log.send('info', 'something', { foo: 'bar' });
   })
+  
+  it('should expose error messages', function(done){
+    var sock = axon.socket('pull');
+    sock.format('json');
+    sock.bind('tcp://localhost:5556');
+    
+    sock.on('message', function(_){
+      assert('something' == _.type);
+      assert('message' == _.message.message);
+      assert('bar' == _.message.foo);
+      done();
+    });
+    
+    var log = new Logger('tcp://localhost:5556');
+    
+    var error = new Error('message');
+    error.foo = 'bar';
+    log.send('error', 'something', error);
+  })
 })
 
 ;['debug', 'info', 'warn', 'error', 'critical', 'alert', 'emergency'].forEach(function(level){


### PR DESCRIPTION
So:

``` js
var err = new Error('message');
err.foo = 'bar';
log.error('oops', err); // => { foo: 'bar', message: 'message' }
// instead of { foo: 'bar' }
```

For perf: http://jsperf.com/make-property-enumerable
