### PR TITLE
limit axon hwm to 100 to prevent leaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,15 +48,18 @@ var levels = exports.levels = {
  * Initialize a logger with the given `addrs`.
  *
  * @param {Array|String} addrs
+ * @param {Object} options
  * @api public
  */
 
-function Logger(addrs) {
+function Logger(addrs, options) {
   if ('string' == typeof addrs) addrs = [addrs];
+  options = options || {};
   this.filter = levels[filter];
   assert(addrs, 'log-server addresses required');
   this.stdio = true;
   this.sock = axon.socket('push');
+  this.sock.set('hwm', options.hwm || Infinity);
   this.sock.format('json');
   this.connect(addrs);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,11 @@ describe('Logger#send(level, type, msg)', function(){
     error.foo = 'bar';
     log.send('error', 'something', error);
   })
+
+  it('should respect hwm setting', function(){
+    var log = new Logger('tcp://leak:4000', { hwm: 100 });
+    assert(log.sock.get('hwm') == 100);
+  })
 })
 
 ;['debug', 'info', 'warn', 'error', 'critical', 'alert', 'emergency'].forEach(function(level){


### PR DESCRIPTION
By default axon hwm is set to Infinity, if it cannot connect to the log-server
it will not flush the messages and keep .push()ing them.

This makes sure that axon will drop messages when the queue reaches 100 even if the connection
cannot be established.

cc @gjohnson 