### PR TITLE
Add option to indent Json output.

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,11 @@ function Logger(addrs, options) {
   this.filter = levels[filter];
   assert(addrs, 'log-server addresses required');
   this.stdio = true;
+  this.indent = 2; // 2 is the default legacy value.
+  // 0 is a valid value, so use hasOwnProperty.
+  if (options.hasOwnProperty('indent')) {
+    this.indent = options.indent;
+  }
   this.sock = axon.socket('push');
   this.sock.set('hwm', options.hwm || Infinity);
   this.sock.format('json');
@@ -119,9 +124,9 @@ Logger.prototype.send = function(level, type, msg){
   if (this.stdio && !test) {
     var meth = n > levels.info ? 'error' : 'log';
     if ('dev' == env) {
-      console[meth]('%s - %s - %s', level, type, stringify(msg, null, 2));
+      console[meth]('%s - %s - %s', level, type, stringify(msg, null, this.indent));
     } else {
-      console[meth]('%s (%s) - %s - %s', now.toUTCString(), level, type, stringify(msg, null, 2));
+      console[meth]('%s (%s) - %s - %s', now.toUTCString(), level, type, stringify(msg, null, this.indent));
     }
   }
 


### PR DESCRIPTION
Before (this is still the default if nothing is supplied for the indent option).
```
info - viewed page - {
  "user": "tobi"
}
info - viewed page - {
  "user": "tobi"
}
info - viewed page - {
  "user": "tobi"
}
```

After, if you supply an indent value manually. In this example I
supplied 0 `var log = new Logger([], { indent: 0 });`.
```
info - viewed page - {"user":"tobi"}
info - viewed page - {"user":"tobi"}
info - viewed page - {"user":"tobi"}
info - signed in - {"user":"jane"}
```

For Segment reviewers - we'll need this so that each log in production is in a single line.

This is required because the ecs agent we run on our machines grabs logs from
stdout and treats each line as a different log statement.

This is problematic (at least for integrations) because this overloads
our loggly account and blows past our limits.